### PR TITLE
Use etag as filename for uploaded resources

### DIFF
--- a/src/upload/index.jsx
+++ b/src/upload/index.jsx
@@ -96,9 +96,7 @@ export default UIFramework.Component(class extends React.Component {
   }
   beforeUpload(file) {
     this.uploadData = {
-      'key': file.name,
       'token': this.props.token,
-      'x:filename': file.name,
       'x:size': file.size,
     };
   }


### PR DESCRIPTION
R= @yorkie @zhangweijie-cn 

> If no _saveKey_ was specified while generating Upload Token, Qiniu will give uploaded file a hash (etag) as its filename, according to Qiniu PutPolicy Documentation. This filename is more prefered than its original filename because original filenames may collide and thus may results resources been overwritten, or modified accidentally.
