### PR TITLE
Fixup dependicies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "classnames": "2.2.3",
     "css-animation": "1.2.1",
     "less": "2.6.1",
+    "rc-align": "2.3.2",
     "rc-animate": "2.0.3",
     "rc-notification": "1.3.2",
     "rc-progress": "1.0.4",


### PR DESCRIPTION
R= @yorkie 

I got following error message while trying to build [studio-web](https://github.com/weflex/studio-web) on my new MacBook,

> ERROR in ./~/weflex-ui/lib/modal/dialog/src/Dialog.js
> Module not found: Error: Cannot resolve module 'rc-align' in /Users/scott/Projects/weflex/studio-web/node_modules/weflex-ui/lib/modal/dialog/src
>  @ ./~/weflex-ui/lib/modal/dialog/src/Dialog.js 37:15-34

I found that it's caused by [src/modal/dialog/src/Dialog.js](https://github.com/weflex/weflex-ui/blob/f674bf31e946dc80fcf61f9fdda7fb9c0cbbb11d/src/modal/dialog/src/Dialog.js) that referencing a package `rc-align` which is not declared in _package.json_.

This patch should fixes the issue above. 

Thanks.
